### PR TITLE
Update ring percentage example value

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ public class MLBusinessLoyaltyRingDataSample implements MLBusinessLoyaltyRingDat
 
     @Override
     public float getRingPercentage() {
-        return 60f;
+        return 0.6f;
     }
 
     @Override


### PR DESCRIPTION
The ringPercentage example is wrong, the percentage admits values between 0 and 1. A value of 60f would result in the whole ring painted and misleads to think the range is 0 to 100.