### PR TITLE
[Loyalty] Modificamos el alto de los items del discounts center

### DIFF
--- a/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="@dimen/ui_view_discount_box_width"
-    android:layout_height="@dimen/ui_view_discount_box_height"
+    android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 


### PR DESCRIPTION
Queremos corregir un detalle que nos quedó pendiente por parte de UX. 
## Antes 
Se cortaba el monto del descuento si se ponía el tamaño de la fuente en grande.

![output-onlinepngtools](https://user-images.githubusercontent.com/34245236/70058690-26f85580-15be-11ea-81ee-42a9ae455f4e.png)

## Después


![output-onlinepngtools (1)](https://user-images.githubusercontent.com/34245236/70058946-a423ca80-15be-11ea-8fbd-dc41c5abdab6.png)

