### PR TITLE
[FIX] Discounts center item logo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.1.2
+_06_01_2020_
+* FIX - Discounts center item fix.
+
 ## VERSION 1.1.1
 _19_12_2019_
 * REFACTOR - Overlay on discount box image

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # Current lib version
-version_to_deploy=1.1.1
+version_to_deploy=1.1.2
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
@@ -31,9 +31,7 @@
                 android:layout_marginEnd="12dp"
                 android:layout_marginStart="12dp"
                 android:layout_marginBottom="12dp"
-                android:layout_marginTop="@dimen/ui_025m"
-                android:paddingStart="@dimen/ui_view_discounts_center_item_side_padding"
-                android:paddingEnd="@dimen/ui_view_discounts_center_item_side_padding">
+                android:layout_marginTop="@dimen/ui_025m">
 
                 <ImageView
                     android:id="@+id/iconImage"

--- a/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
@@ -12,7 +12,9 @@
         android:layout_height="match_parent"
         app:cardCornerRadius="6dp"
         app:cardElevation="0dp"
-        app:cardUseCompatPadding="true">
+        app:cardUseCompatPadding="true"
+        android:paddingStart="@dimen/ui_view_discounts_center_item_side_padding"
+        android:paddingEnd="@dimen/ui_view_discounts_center_item_side_padding">
 
         <LinearLayout
             android:id="@+id/cardView"

--- a/mlbusinesscomponents/src/main/res/values/dimen.xml
+++ b/mlbusinesscomponents/src/main/res/values/dimen.xml
@@ -8,7 +8,7 @@
     <dimen name="ui_view_download_icon_width">34dp</dimen>
     <dimen name="ui_view_download_icon_height">24dp</dimen>
 
-    <dimen name="ui_view_discounts_center_item_side_padding">8dp</dimen>
+    <dimen name="ui_view_discounts_center_item_side_padding">4dp</dimen>
     <dimen name="ui_view_discounts_center_item_height_padding">12dp</dimen>
 
     <!-- Font Dimens -->


### PR DESCRIPTION
## Descripción
Se realizan cambios para evitar que los componentes del _discounts-center_ se vean cortados.
_Emulador de nexus One_

## Antes
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/71839896-fdd65380-309a-11ea-995b-6d0c2fbb8d83.png" width="300" height="500" align="middle"/>
</p>

## Después
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/71842342-26148100-30a0-11ea-861a-971afc005426.png" width="300" height="500" align="middle"/>
</p>

