### PR TITLE
[FIX] espacio lateral entre items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## VERSION 1.1.3
-_06_01_2020_
+_15_01_2020_
 * FIX - Discounts center, lateral space between items.
 
 ## VERSION 1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.1.3
+_06_01_2020_
+* FIX - Discounts center, lateral space between items.
+
 ## VERSION 1.1.2
 _06_01_2020_
 * FIX - Discounts center item fix.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # Current lib version
-version_to_deploy=1.1.2
+version_to_deploy=1.1.3
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.mlbusinesscomponents.components.discount;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Rect;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -16,6 +17,9 @@ import com.mercadolibre.android.mlbusinesscomponents.components.utils.ScaleUtils
 import com.mercadolibre.android.mlbusinesscomponents.components.utils.ViewUtils;
 import java.lang.ref.WeakReference;
 import java.util.List;
+
+import static android.util.DisplayMetrics.DENSITY_LOW;
+import static android.util.DisplayMetrics.DENSITY_MEDIUM;
 
 public class MLBusinessDiscountBoxView extends ConstraintLayout {
 
@@ -121,6 +125,7 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
     }
 
     private static class SpacesItemDecoration extends RecyclerView.ItemDecoration {
+        private static final int MINIMUM_PIXELS_WIDTH = 720;
         private final int topSpace;
         private final int lateralSpace;
         private final int itemsInLastRow;
@@ -128,9 +133,17 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
 
         SpacesItemDecoration(final Context context, final int itemsInLastRow, final int defaultColumns) {
             topSpace = (int) ScaleUtils.getPxFromDp(context, 0);
-            lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16);
+            if (isSmallDevice()) {
+                lateralSpace = 0;
+            } else {
+                lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16);
+            }
             this.itemsInLastRow = itemsInLastRow;
             this.defaultColumns = defaultColumns;
+        }
+
+        private boolean isSmallDevice() {
+            return ((int) Resources.getSystem().getDisplayMetrics().xdpi) < MINIMUM_PIXELS_WIDTH;
         }
 
         @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -18,8 +18,6 @@ import com.mercadolibre.android.mlbusinesscomponents.components.utils.ViewUtils;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
-import static android.util.DisplayMetrics.DENSITY_LOW;
-import static android.util.DisplayMetrics.DENSITY_MEDIUM;
 
 public class MLBusinessDiscountBoxView extends ConstraintLayout {
 

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -123,7 +123,7 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
     }
 
     private static class SpacesItemDecoration extends RecyclerView.ItemDecoration {
-        private static final int MINIMUM_PIXELS_WIDTH = 720;
+        private static final int MINIMUM_PIXELS_WIDTH = 1080;
         private final int topSpace;
         private final int lateralSpace;
         private final int itemsInLastRow;
@@ -134,14 +134,14 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
             if (isSmallDevice()) {
                 lateralSpace = 0;
             } else {
-                lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16);
+                lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16.0f);
             }
             this.itemsInLastRow = itemsInLastRow;
             this.defaultColumns = defaultColumns;
         }
 
         private boolean isSmallDevice() {
-            return ((int) Resources.getSystem().getDisplayMetrics().xdpi) < MINIMUM_PIXELS_WIDTH;
+            return Resources.getSystem().getDisplayMetrics().widthPixels < MINIMUM_PIXELS_WIDTH;
         }
 
         @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -128,7 +128,7 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
 
         SpacesItemDecoration(final Context context, final int itemsInLastRow, final int defaultColumns) {
             topSpace = (int) ScaleUtils.getPxFromDp(context, 0);
-            lateralSpace = (int) ScaleUtils.getPxFromDp(context, 10);
+            lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16);
             this.itemsInLastRow = itemsInLastRow;
             this.defaultColumns = defaultColumns;
         }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -128,7 +128,7 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
 
         SpacesItemDecoration(final Context context, final int itemsInLastRow, final int defaultColumns) {
             topSpace = (int) ScaleUtils.getPxFromDp(context, 0);
-            lateralSpace = (int) ScaleUtils.getPxFromDp(context, 0);
+            lateralSpace = (int) ScaleUtils.getPxFromDp(context, 10);
             this.itemsInLastRow = itemsInLastRow;
             this.defaultColumns = defaultColumns;
         }


### PR DESCRIPTION
# Descripcion
Se corrige el espacio entre items de la central de descuentos.

## Antes
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/72455309-4ed3ff00-37a1-11ea-8c84-035562f01ccc.png" width="300" height="500" align="middle"/>
</p>

## Despues 
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/72455368-67dcb000-37a1-11ea-916e-aa899f4f814b.png" width="300" height="500" align="middle"/>
</p>

# UPDATE con ML
### Resolución pequeña
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73011858-dfd75580-3df3-11ea-93e2-41b6d47c0a20.png" width="300" height="500" align="middle"/>
</p>

### Resolución mediana
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73011981-1ad98900-3df4-11ea-9402-1304867d0a2b.png" width="300" height="500" align="middle"/>
</p>

### Resolución grande 
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73012104-64c26f00-3df4-11ea-92bc-42746adf42d7.png" width="300" height="600" align="middle"/>
</p>


