### PR TITLE
Fix in loyalty discounts center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.1.4
+_28_01_2020_
+* FIX - Discounts center, icons showing incorrectly in small and high resolution devices.
+
 ## VERSION 1.1.3
 _15_01_2020_
 * FIX - Discounts center, lateral space between items.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # Current lib version
-version_to_deploy=1.1.3
+version_to_deploy=1.1.4
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxAdapter.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxAdapter.java
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.mlbusinesscomponents.components.discount;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -15,6 +16,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import com.mercadolibre.android.mlbusinesscomponents.R;
 import com.mercadolibre.android.mlbusinesscomponents.common.MLBusinessSingleItem;
+import com.mercadolibre.android.mlbusinesscomponents.components.utils.ScaleUtils;
 import com.mercadolibre.android.mlbusinesscomponents.components.utils.StringUtils;
 import com.mercadolibre.android.picassodiskcache.PicassoDiskLoader;
 import java.lang.ref.WeakReference;
@@ -54,6 +56,7 @@ class MLBusinessDiscountBoxAdapter
 
     class DiscountBoxViewHolder extends RecyclerView.ViewHolder {
         final ImageView iconImage;
+        final View iconOverlay;
         final TextView titleLabel;
         final TextView subtitleLabel;
         final LinearLayout cardView;
@@ -62,6 +65,7 @@ class MLBusinessDiscountBoxAdapter
             super(itemView);
 
             iconImage = itemView.findViewById(R.id.iconImage);
+            iconOverlay = itemView.findViewById(R.id.iconOverlay);
             titleLabel = itemView.findViewById(R.id.titleLabel);
             subtitleLabel = itemView.findViewById(R.id.subtitleLabel);
             cardView = itemView.findViewById(R.id.cardView);
@@ -120,6 +124,9 @@ class MLBusinessDiscountBoxAdapter
 
         void loadIconImage(@NonNull final String url) {
             final Context context = itemView.getContext();
+            if (Resources.getSystem().getDisplayMetrics().widthPixels <= 480) {
+                resizeIconImage(context);
+            }
             if (context != null) {
                 PicassoDiskLoader.get(context)
                     .load(Uri.parse(url))
@@ -127,6 +134,18 @@ class MLBusinessDiscountBoxAdapter
                     .placeholder(R.drawable.skeleton)
                     .into(iconImage);
             }
+        }
+
+        private void resizeIconImage(Context context) {
+            ViewGroup.LayoutParams iconImageParams = iconImage.getLayoutParams();
+            ViewGroup.LayoutParams overlayParams = iconOverlay.getLayoutParams();
+            int iconNewSize = (int) ScaleUtils.getPxFromDp(context, 48.0f);
+            iconImageParams.height = iconNewSize;
+            iconImageParams.width = iconNewSize;
+            overlayParams.height = iconNewSize;
+            overlayParams.width = iconNewSize;
+            iconImage.setLayoutParams(iconImageParams);
+            iconOverlay.setLayoutParams(overlayParams);
         }
     }
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/discount/MLBusinessDiscountBoxView.java
@@ -134,7 +134,7 @@ public class MLBusinessDiscountBoxView extends ConstraintLayout {
             if (isSmallDevice()) {
                 lateralSpace = 0;
             } else {
-                lateralSpace = (int) ScaleUtils.getPxFromDp(context, 16.0f);
+                lateralSpace = (int) ScaleUtils.getPxFromDp(context, 10.0f);
             }
             this.itemsInLastRow = itemsInLastRow;
             this.defaultColumns = defaultColumns;

--- a/mlbusinesscomponents/src/main/res/layout/ml_view_business_discount_box.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_business_discount_box.xml
@@ -55,8 +55,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:layout_height="200dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"

--- a/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_discount_box.xml
@@ -44,6 +44,7 @@
                     android:contentDescription="@string/app_name" />
 
                 <View
+                    android:id="@+id/iconOverlay"
                     android:layout_width="@dimen/ui_7m"
                     android:layout_height="@dimen/ui_7m"
                     android:background="@drawable/box_icon_overlay" />


### PR DESCRIPTION
## Descripción

Se busca arreglar los márgenes y espaciados entre items para evitar que se corten los items dentro de la central de descuentos

## Tipo:

- [x ] Bugfix

## Pruebas
Realizamos pruebas en distintos tipos de devices para garantizar que las soluciones propuestas sean validas, los devices utilizados fueron de las siguientes dimensiones 
- 480 x 800 px (tamaño chico)
- 720 x 1280 px (mediano)
- 1080 x 2160 px (grande)
- 1440 x 2960 px (muy grande)

En orden de manor a mayor tamaño, se presentan capturas de pantalla de los casos antes y despues de lso cambios propuestos

## Antes
<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234217-e81ef000-4167-11ea-8213-7718b18fbc87.png" width="310" height="400" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234319-48ae2d00-4168-11ea-8636-ce01af158065.png" width="300" height="400" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234348-69768280-4168-11ea-87cc-abccdbfeb9fa.png" width="300" height="370" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234363-74c9ae00-4168-11ea-9619-4dd4c1664d26.png" width="300" height="370" align="middle"/>
</p>

## Después 

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234740-39c87a00-416a-11ea-92b5-ff364ece8a1f.png" width="310" height="400" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234756-46e56900-416a-11ea-9f6d-de54a1675cbb.png" width="300" height="400" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234784-667c9180-416a-11ea-92ad-f231a1663e4d.png" width="300" height="370" align="middle"/>
</p>

<p align="center">
<img src="https://user-images.githubusercontent.com/34245236/73234822-890eaa80-416a-11ea-9286-484ea4299f73.png" width="300" height="370" align="middle"/>
</p>






