### PR TITLE
[WIP] Remover logo de componente de descargas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.1.9
+_20_03_2020_
+* FEATURE - Download logo can disappear
+
 ## VERSION 1.1.8
 _04_03_2020_
 * FEATURE - Loyalty broadcast

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # Current lib version
-version_to_deploy=1.1.8
+version_to_deploy=1.1.9
 # Compile versions
 build_tools_version=28.0.3
 min_api_level=19

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/common/downloadapp/MLBusinessDownloadAppView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/common/downloadapp/MLBusinessDownloadAppView.java
@@ -5,13 +5,21 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.constraint.ConstraintLayout;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.AppCompatImageView;
 import android.support.v7.widget.AppCompatTextView;
+import android.text.Layout;
 import android.util.AttributeSet;
+import android.view.ViewTreeObserver;
+
 import com.mercadolibre.android.mlbusinesscomponents.R;
 import com.mercadolibre.android.ui.widgets.MeliButton;
+
 import java.lang.ref.WeakReference;
 
 public class MLBusinessDownloadAppView extends ConstraintLayout {
+
+    private AppCompatImageView logoImage;
+    private AppCompatTextView downloadTitle;
 
     public interface OnClickDownloadApp {
         void OnClickDownloadAppButton(@NonNull final String deepLink);
@@ -40,9 +48,13 @@ public class MLBusinessDownloadAppView extends ConstraintLayout {
     }
 
     public void init(@NonNull final MLBusinessDownloadAppData businessDownloadAppData,
-        @NonNull final OnClickDownloadApp onClick) {
-        findViewById(R.id.imageSite).setBackgroundResource(businessDownloadAppData.getAppSite().getResource());
-        ((AppCompatTextView) findViewById(R.id.titleDownload)).setText(businessDownloadAppData.getTitle());
+                     @NonNull final OnClickDownloadApp onClick) {
+        logoImage = findViewById(R.id.imageSite);
+        logoImage.setBackgroundResource(businessDownloadAppData.getAppSite().getResource());
+
+        downloadTitle = findViewById(R.id.titleDownload);
+        downloadTitle.setText(businessDownloadAppData.getTitle());
+        downloadTitle.getViewTreeObserver().addOnGlobalLayoutListener(getRemoveSiteLogoListener());
 
         final MeliButton downloadButton = findViewById(R.id.downloadButton);
         downloadButton.setText(businessDownloadAppData.getButtonTitle());
@@ -56,9 +68,32 @@ public class MLBusinessDownloadAppView extends ConstraintLayout {
     }
 
     public void updateView(@NonNull final MLBusinessDownloadAppData businessDownloadAppData,
-        @NonNull final OnClickDownloadApp onClick) {
+                           @NonNull final OnClickDownloadApp onClick) {
         init(businessDownloadAppData, onClick);
     }
+
+    private boolean textIsEllipsized(AppCompatTextView text) {
+        Layout titleLayout = text.getLayout();
+        return titleLayout != null && titleLayout.getLineCount() > 0 && titleLayout.getEllipsisCount(titleLayout.getLineCount() - 1) > 0;
+    }
+
+    private ViewTreeObserver.OnGlobalLayoutListener getRemoveSiteLogoListener() {
+        return new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                if (textIsEllipsized(downloadTitle)) {
+                    logoImage.setVisibility(GONE);
+                }
+            }
+
+            @Override
+            protected void finalize() throws Throwable {
+                super.finalize();
+                downloadTitle.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+            }
+        };
+    }
+
 
     public enum AppSite {
         ML(R.drawable.mercado_libre),


### PR DESCRIPTION
## Descripción

- Se agrega lógica para remover el logo de Mercado Libre o Mercado Puntos en el casi de que el texto no llegue a entrar en el espacio disponible. Esto es para los casos de devices con resolución baja usualmente.

## Screenshots - Gifs

<img width="323" alt="Captura de Pantalla 2020-03-20 a la(s) 14 36 38" src="https://user-images.githubusercontent.com/34245163/77190561-3db4b080-6ab8-11ea-912a-c63814833d17.png">
<img width="326" alt="Captura de Pantalla 2020-03-20 a la(s) 14 36 26" src="https://user-images.githubusercontent.com/34245163/77190603-52914400-6ab8-11ea-8f2c-a3ac0d9ad92a.png">


### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [X] Probé la biblioteca en Mercado Pago (Obligatorio)
- [X] Probé la biblioteca en Mercado Libre (Obligatorio)
- [X] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
