### PR TITLE
refactor - fix onClick. Se elimino el startAnimationCustom.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.2.1
+_30_04_2020_
+* REFACTOR - Refactor exploting button, fix onClick
+
 ## VERSION 1.2.0
 _22_04_2020_
 * REFACTOR - Refactor exploting button by status bar

--- a/app/src/main/java/com/mercadolibre/android/mlbusinesscomponentsapp/ButtonsActivity.java
+++ b/app/src/main/java/com/mercadolibre/android/mlbusinesscomponentsapp/ButtonsActivity.java
@@ -20,8 +20,10 @@ public class ButtonsActivity extends AppCompatActivity {
                 .setTextInformation("Procesar Pago","Cargando")
                 .setColorText(R.color.ui_meli_red);
 
-        buttonProgress.setOnClickListener(v ->
-                Toast.makeText(ButtonsActivity.this,"hola", Toast.LENGTH_SHORT).show()
+        buttonProgress.setOnClickListener(v -> {
+                Toast.makeText(ButtonsActivity.this,"hola", Toast.LENGTH_SHORT).show();
+                buttonProgress.startAnimationCustom();
+            }
         );
 
         new Handler().postDelayed(buttonProgress::startAnimationCustom, 3000);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
@@ -225,7 +225,6 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
 
     @Override
     public void onClick(View v) {
-        startAnimationCustom();
         if (onClickListener != null) {
             onClickListener.onClick(v);
             setClickable(false);


### PR DESCRIPTION
## Descripción
Se elimina la ejecución del startanimationCustom del metodo onClick

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [X] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
