### PR TITLE
Restore card height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEW
 
+* FIX - Se restaura el alto de la card
+
 ## VERSION 1.6.1
 _17_07_2020_
 * FEATURE - Se modifica el largo del titulo y subtitulo de las cards del carrusel

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/domain/model/carousel/CarouselCard.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/domain/model/carousel/CarouselCard.java
@@ -198,7 +198,7 @@ public class CarouselCard implements TouchpointTrackeable, Serializable {
             hasSubtitle = true;
         }
 
-        double spaceToMainLabel = 100, topLabelHeight = 14, mainLabelHeight = 28, titleHeight = 23, subtitleHeight = 13, spaceToBottom = 28;
+        final double spaceToMainLabel = 100, topLabelHeight = 14, mainLabelHeight = 28, titleHeight = 23, subtitleHeight = 13, spaceToBottom = 13;
 
         double maxItemHeight = spaceToMainLabel
             + (hasTopLabel ? topLabelHeight : 0.0)


### PR DESCRIPTION
## Descripción

Se restaura el alto de la card al valor previo

## Tipo:

- [X] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
