### PR TITLE
CoverCarousel Visual Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.16.1
+## new
 - Se reduce en 4dp el margen superior del CoverCarousel
 
 ## 1.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.16.1
+- Se reduce en 4dp el margen superior del CoverCarousel
+
 ## 1.16.0
 - Se mejora el CoverCarousel reutilizando las vistas creadas.
 

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
@@ -11,7 +11,7 @@
         android:id="@+id/touchpoint_cover_carousel_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/ui_2m"
+        android:paddingTop="@dimen/ui_1_5m"
         android:orientation="vertical">
 
         <LinearLayout


### PR DESCRIPTION
## Descripción
-  Reduzco el padding top de 16dp a 12dp para el CoverCarousel

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs
**Antes y Después**
![Screen Shot 2021-02-01 at 17 13 08](https://user-images.githubusercontent.com/51420540/106515197-168a8600-64b4-11eb-9590-353a28a38ffc.png)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
