### PR TITLE
Release 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## new
+## 1.16.1
 - Se reduce en 4dp el margen superior del CoverCarousel
 
 ## 1.16.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 org.gradle.daemon=true
 # Current lib version
-version_to_deploy=1.16.0
+version_to_deploy=1.16.1
 # Compile versions
 buildTools=29.0.2
 minApiLevel=19


### PR DESCRIPTION
## Descripción
- [FIX] Se reduce en 4dp el margen superior del CoverCarousel

## Tipo:

- [ ] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
