### PR TITLE
Fix skeleton cover y row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.19.0
+- Se elimina del skeleton de la hybrid row
+- Se arregla las condiciones para disparar el skeleton del cover carousel
+
 ## 1.18.1
 - Se arregla top Image status
 

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselPresenter.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselPresenter.java
@@ -15,7 +15,7 @@ public class CoverCarouselPresenter {
      */
     public void mapResponse(final CoverCarouselInterfaceModel response, final CoverCarouselViewInterface view) {
 
-        if (response == null) {
+        if (response == null || response.getItems() == null) {
             view.showSkeleton();
             return;
         }

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_row_skeleton.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_row_skeleton.xml
@@ -53,10 +53,4 @@
         </LinearLayout>
     </LinearLayout>
 
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/ui_0125m"
-        android:background="@color/ui_components_light_grey_color" />
-
 </LinearLayout>


### PR DESCRIPTION
## Descripción
- Se elimina del skeleton de la hybrid row
- Se arregla las condiciones para disparar el skeleton del cover carousel

## Tipo:

- [ ] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

![skeleton cover y row](https://user-images.githubusercontent.com/45605274/120021947-1a419b80-bfc2-11eb-8730-62685c14da55.gif)


### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [x] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [x] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
