### PR TITLE
Added default status

### DIFF
--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowPresenter.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowPresenter.java
@@ -88,7 +88,7 @@ public class TouchpointRowPresenter {
             view.hideCharacteristicsLabels();
             return;
         }
-        view.showCharacterísticsLabels(mainDescription);
+        view.showCharacteristicsLabels(mainDescription);
     }
 
     private void setStatusDescription(final List<DescriptionItemsInterface> statusDescription, final TouchpointRowView view) {
@@ -178,6 +178,8 @@ public class TouchpointRowPresenter {
 
         if (CLOSED.equals(status.toLowerCase())) {
             view.setTitleToClosedStatus();
+        } else {
+            view.setDefaultTitleClosedStatus();
         }
     }
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
@@ -150,6 +150,14 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
     }
 
     /**
+     * Set default title and subtitle closed status
+     **/
+    public void setDefaultTitleClosedStatus() {
+        mainTitle.setTextColor(getResources().getColor(R.color.semi_black));
+        mainSubtitle.setTextColor(getResources().getColor(R.color.semi_black));
+    }
+
+    /**
      * Hide brand name
      **/
     public void hideTitle() {
@@ -332,7 +340,7 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
      *
      * @param mainDescription the labels.
      */
-    public void showCharacterísticsLabels(final List<DescriptionItemsInterface> mainDescription) {
+    public void showCharacteristicsLabels(final List<DescriptionItemsInterface> mainDescription) {
         if (mainCharacteristicsContainer != null) {
             mainCharacteristicsContainer.bindViews(mainDescription);
         }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
@@ -153,8 +153,8 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
      * Set default title and subtitle closed status
      **/
     public void setDefaultTitleClosedStatus() {
-        mainTitle.setTextColor(getResources().getColor(R.color.semi_black));
-        mainSubtitle.setTextColor(getResources().getColor(R.color.semi_black));
+        mainTitle.setAlpha(ENABLE_VIEW);
+        mainSubtitle.setAlpha(ENABLE_VIEW);
     }
 
     /**
@@ -310,10 +310,10 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
     }
 
     public void setRightLabelsToDefaultStatus() {
-        rightContainer.setAlpha(1f);
-        rightMiddleLabel.setAlpha(1f);
-        rightPrimaryLabel.setAlpha(1f);
-        rightSecondaryLabel.setAlpha(1f);
+        rightContainer.setAlpha(ENABLE_VIEW);
+        rightMiddleLabel.setAlpha(ENABLE_VIEW);
+        rightPrimaryLabel.setAlpha(ENABLE_VIEW);
+        rightSecondaryLabel.setAlpha(ENABLE_VIEW);
     }
 
     public void hideRightBottomInfo() {


### PR DESCRIPTION
## Descripción

- Se agrega default status para quitar el alpha por la reutilizacion de views. Al scrollear y reutilizarse las vistas, quedaba seteado el alpha correspondiente al status Closed. Ahora se setea el status default (sin alpha) o el alpha correspondiente.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

En el primer scroll se obversan correctamente. 
<img width="334" alt="Screen Shot 2021-07-14 at 12 21 38" src="https://user-images.githubusercontent.com/4195740/125648679-c937cdce-285d-44c4-91ad-d568dad8a06f.png">

En este caso, al scrollear para arriba, los Stores se mostraban con el title y subtitle como status Closed. 
<img width="328" alt="Screen Shot 2021-07-14 at 12 21 16" src="https://user-images.githubusercontent.com/4195740/125648699-e4fc2d8b-a6fa-4dc5-a74e-2dcc5d348a20.png">


[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
