### PR TITLE
CoverCarousel -> Fix + Touchpoint Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Sin Publicar
+- Se arregla la altura del CoverCarousel.
 
 ## 1.20.1
 - Se agrega default en el método de la interface TouchpointRowItemInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Sin Publicar
 - Se arregla la altura del CoverCarousel.
+- Se agrega la decoración por AdditionalInsets para utilizar el CoverCarousel como Touchpoint en la Home de la Wallet.
 
 ## 1.20.1
 - Se agrega default en el método de la interface TouchpointRowItemInterface

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselPresenter.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselPresenter.java
@@ -74,5 +74,6 @@ public class CoverCarouselPresenter {
         }
 
         view.setViewPagerHeight(maxCoverCardHeight, isSkeletonVisible);
+        view.decorate();
     }
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
@@ -16,6 +16,7 @@ import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.domai
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.domain.model.cover_carousel.response.CoverCarouselInterfaceModel;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.view.AbstractTouchpointChildView;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.view.carousel.card.TrackListener;
+import com.mercadolibre.android.mlbusinesscomponents.components.utils.ScaleUtils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,6 +121,18 @@ public class CoverCarouselView extends AbstractTouchpointChildView<CoverCarousel
         viewPagerAdapter.setElementsView(items);
         viewPager.setCurrentItem(0);
         presenter.getMaxHeight(viewPagerAdapter.getElementsList(), this);
+    }
+
+    @Override
+    public void decorate() {
+        if (additionalInsets != null) {
+            viewPager.setPadding(
+                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getLeft()),
+                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getTop()),
+                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getRight()),
+                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getBottom())
+            );
+        }
     }
 
     @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import androidx.viewpager.widget.ViewPager;
 import com.mercadolibre.android.mlbusinesscomponents.R;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.callback.OnClickCallback;
+import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.domain.model.AdditionalEdgeInsets;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.domain.model.cover_carousel.model.cover_card.CoverCardInterfaceModel;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.domain.model.cover_carousel.response.CoverCarouselInterfaceModel;
 import com.mercadolibre.android.mlbusinesscomponents.components.touchpoint.view.AbstractTouchpointChildView;
@@ -126,13 +127,18 @@ public class CoverCarouselView extends AbstractTouchpointChildView<CoverCarousel
     @Override
     public void decorate() {
         if (additionalInsets != null) {
-            viewPager.setPadding(
-                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getLeft()),
-                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getTop()),
-                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getRight()),
-                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getBottom())
-            );
+            setViewPagerPaddingsFromInsets(additionalInsets);
         }
+    }
+
+    private void setViewPagerPaddingsFromInsets(
+        final AdditionalEdgeInsets additionalInsets) {
+        viewPager.setPadding(
+            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getLeft()),
+            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getTop()),
+            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getRight()),
+            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getBottom())
+        );
     }
 
     @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
@@ -134,11 +134,15 @@ public class CoverCarouselView extends AbstractTouchpointChildView<CoverCarousel
     private void setViewPagerPaddingsFromInsets(
         final AdditionalEdgeInsets additionalInsets) {
         viewPager.setPadding(
-            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getLeft()),
-            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getTop()),
-            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getRight()),
-            (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getBottom())
+            getInsetInPx(additionalInsets.getLeft()),
+            getInsetInPx(additionalInsets.getTop()),
+            getInsetInPx(additionalInsets.getRight()),
+            getInsetInPx(additionalInsets.getBottom())
         );
+    }
+
+    private int getInsetInPx(final int inset) {
+        return (int) ScaleUtils.getPxFromDp(getContext(), inset);
     }
 
     @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
@@ -127,10 +127,10 @@ public class CoverCarouselView extends AbstractTouchpointChildView<CoverCarousel
     public void decorate() {
         if (additionalInsets != null) {
             viewPager.setPadding(
-                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getLeft()),
-                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getTop()),
-                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getRight()),
-                ScaleUtils.getPxFromSp(getContext(), additionalInsets.getBottom())
+                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getLeft()),
+                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getTop()),
+                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getRight()),
+                (int) ScaleUtils.getPxFromDp(getContext(), additionalInsets.getBottom())
             );
         }
     }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselView.java
@@ -134,7 +134,7 @@ public class CoverCarouselView extends AbstractTouchpointChildView<CoverCarousel
             );
             params.height = maxHeight + viewPagerPadding;
         } else {
-            params.height = maxHeight;
+            params.height = maxHeight + getResources().getDimensionPixelSize(R.dimen.ui_2m);
         }
     }
 

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselViewInterface.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/cover_carousel/CoverCarouselViewInterface.java
@@ -30,4 +30,6 @@ public interface CoverCarouselViewInterface {
     void showSkeleton();
 
     void hideSkeleton();
+
+    void decorate();
 }

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/touchpoint_cover_carousel_view_flipper"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:measureAllChildren="false">
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:id="@+id/touchpoint_cover_carousel_container"

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_cover_carousel_view.xml
@@ -5,7 +5,7 @@
     android:id="@+id/touchpoint_cover_carousel_view_flipper"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:parentTag="android.widget.FrameLayout">
+    android:measureAllChildren="false">
 
     <LinearLayout
         android:id="@+id/touchpoint_cover_carousel_container"


### PR DESCRIPTION
## Descripción
- Se arregla el cálculo de la altura del viewPager del cover carousel que causaba que el contenido de la Row esté pegado al bottom.
- Se resuelve agregando a la altura máxima del ViewPager la misma cantidad que se solicita como padding inferior de las Cards internas.
- Se agrega el método decorate() para ajustar los paddings del carousel cuando se implemente como touchpoint en la Home de la wallet.

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvemen

## Screenshots - Gifs
Antes | Después
---- | ----
![Screenshot_20210715-173114_Mercado Pago](https://user-images.githubusercontent.com/51420540/125854800-f5763a27-c381-4366-bec3-d2d424408f99.jpg) | ![Screenshot_20210715-173313](https://user-images.githubusercontent.com/51420540/125854823-37b7e4e5-3611-4641-aff2-f8116d05b899.jpg)
![Screenshot_20210715-173347_Mercado Pago](https://user-images.githubusercontent.com/51420540/125854858-d8d533d6-07b2-4fe3-b157-90b6e9a37ac7.jpg) | ![Screenshot_20210715-173324](https://user-images.githubusercontent.com/51420540/125854871-693dd76e-4302-43d1-b96c-e1721618aee7.jpg)

### Cover Carousel en Home de la Wallet
![home-wallet-cover-carousel](https://user-images.githubusercontent.com/51420540/126206039-9326c5e2-eb59-4847-b972-863df4dc5e40.gif)

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
