### PR TITLE
Rounded image fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Sin Publicar
 - Cambios en el componente de beneficios de Loyalty
+- Se arregla la perdida de calidad de imagenes al redondear con fresco
 
 ## 1.21.0
 - Se arregla la altura del CoverCarousel.

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,4 @@ espresso=3.1.0
 testRunner=1.1.1
 junit=4.+
 gson=2.8.5
+frescoVersion=2.2.0

--- a/mlbusinesscomponents/build.gradle
+++ b/mlbusinesscomponents/build.gradle
@@ -50,4 +50,5 @@ dependencies {
     implementation "com.mercadolibre.android:ui:$meliUi"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayout"
     implementation "androidx.cardview:cardview:$cardView"
+    implementation "com.facebook.fresco:fresco:$frescoVersion"
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
@@ -68,6 +68,10 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
         super(context, attrs);
         inflate(context, R.layout.touchpoint_row_view, this);
         leftImage = findViewById(R.id.left_image);
+        if (leftImage.getHierarchy() != null
+                && leftImage.getHierarchy().getRoundingParams() != null ) {
+            leftImage.getHierarchy().getRoundingParams().setPaintFilterBitmap(true);
+        }
         leftImageAccessory = findViewById(R.id.left_image_accessory);
         mainTitle = findViewById(R.id.main_title);
         mainSubtitle = findViewById(R.id.main_subtitle);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card/CarouselCardView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card/CarouselCardView.java
@@ -86,6 +86,10 @@ public class CarouselCardView extends CardView implements TouchpointTrackeable {
         super(context, attrs, defStyleAttr);
         inflate(getContext(), R.layout.touchpoint_carousel_card_view, this);
         logo = findViewById(R.id.touchpoint_carousel_card_logo);
+        if (logo.getHierarchy() != null
+                && logo.getHierarchy().getRoundingParams() != null ) {
+            logo.getHierarchy().getRoundingParams().setPaintFilterBitmap(true);
+        }
         levelContainer = findViewById(R.id.touchpoint_carousel_card_level_container);
         levelIcon = findViewById(R.id.touchpoint_carousel_card_level_icon);
         levelDescription = findViewById(R.id.touchpoint_carousel_card_level);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/hybrid_carousel/default_card/card/HybridCarouselDefaultCardView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/hybrid_carousel/default_card/card/HybridCarouselDefaultCardView.java
@@ -55,6 +55,10 @@ public class HybridCarouselDefaultCardView extends CardView implements Touchpoin
         inflate(getContext(), R.layout.touchpoint_hybrid_carousel_default_card_view, this);
         topImageContainer = findViewById(R.id.touchpoint_hybrid_carousel_default_card_image_container);
         topImage = findViewById(R.id.touchpoint_hybrid_carousel_default_card_top_image);
+        if (topImage.getHierarchy() != null
+                && topImage.getHierarchy().getRoundingParams() != null ) {
+            topImage.getHierarchy().getRoundingParams().setPaintFilterBitmap(true);
+        }
         topImageAccessory = findViewById(R.id.touchpoint_hybrid_carousel_default_card_top_image_accessory);
         middleTitle = findViewById(R.id.touchpoint_hybrid_carousel_default_card_middle_title);
         middleSubtitle = findViewById(R.id.touchpoint_hybrid_carousel_default_card_middle_subtitle);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/hybrid_carousel/view_more/card/HybridCarouselViewMoreCardView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/hybrid_carousel/view_more/card/HybridCarouselViewMoreCardView.java
@@ -41,7 +41,10 @@ public class HybridCarouselViewMoreCardView extends CardView implements Touchpoi
         inflate(getContext(), R.layout.touchpoint_hybrid_carousel_view_more_card_view, this);
         middleTitle = findViewById(R.id.touchpoint_hybrid_carousel_view_more_card_middle_title);
         topImage = findViewById(R.id.touchpoint_hybrid_carousel_view_more_card_top_image);
-
+        if (topImage.getHierarchy() != null
+                && topImage.getHierarchy().getRoundingParams() != null ) {
+            topImage.getHierarchy().getRoundingParams().setPaintFilterBitmap(true);
+        }
         presenter = new HybridViewMoreCardPresenter(this);
     }
 

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_carousel_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_carousel_card_view.xml
@@ -30,10 +30,10 @@
                 android:id="@+id/touchpoint_carousel_card_logo"
                 android:layout_width="@dimen/ui_9m"
                 android:layout_height="@dimen/ui_9m"
-                android:scaleType="fitCenter"
+                android:scaleType="centerCrop"
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
-                app:actualImageScaleType="fitCenter"
+                app:actualImageScaleType="centerCrop"
                 app:roundAsCircle="true"
                 android:contentDescription="@string/app_name" />
 

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_default_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_default_card_view.xml
@@ -29,11 +29,10 @@
                 android:id="@+id/touchpoint_hybrid_carousel_default_card_top_image"
                 android:layout_width="@dimen/ui_9m"
                 android:layout_height="@dimen/ui_9m"
-                android:scaleType="fitCenter"
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
                 app:roundAsCircle="true"
-                app:actualImageScaleType="fitCenter"
+                app:actualImageScaleType="centerCrop"
                 android:contentDescription="@string/app_name" />
 
             <View

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_view_more_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_view_more_card_view.xml
@@ -32,10 +32,11 @@
                 android:id="@+id/touchpoint_hybrid_carousel_view_more_card_top_image"
                 android:layout_width="@dimen/ui_9m"
                 android:layout_height="@dimen/ui_9m"
-                android:scaleType="fitCenter"
+                android:scaleType="centerCrop"
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
                 app:roundAsCircle="true"
+                app:actualImageScaleType="centerCrop"
                 android:contentDescription="@string/app_name" />
 
             <View

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_row_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_row_view.xml
@@ -25,10 +25,10 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.0"
             app:layout_constraintVertical_chainStyle="packed"
-            fresco:actualImageScaleType="fitCenter"
+            app:actualImageScaleType="centerCrop"
             fresco:overlayImage="@color/row_logo_overlay"
-            fresco:placeholderImage="@drawable/oval_skeleton"
-            fresco:roundAsCircle="true" />
+            app:placeholderImage="@drawable/oval_skeleton"
+            app:roundAsCircle="true" />
 
         <com.facebook.drawee.view.SimpleDraweeView
             android:id="@+id/left_image_accessory"
@@ -39,7 +39,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/left_image"
             app:layout_constraintEnd_toEndOf="@+id/left_image"
             app:layout_constraintVertical_chainStyle="packed"
-            fresco:actualImageScaleType="fitCenter"
+            fresco:actualImageScaleType="centerCrop"
             fresco:roundAsCircle="true" />
 
         <TextView


### PR DESCRIPTION
## Descripción

- Se arregla la perdida de calidad por redondeo de imagenes 


basado en https://github.com/facebook/fresco/pull/2294/files

## Tipo:

- [ ] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

Pro que se cambio de FIT_CENTER a CENTER_CROP:
<img width="928" alt="Captura de pantalla 2021-08-10 a las 2 52 51 p  m" src="https://user-images.githubusercontent.com/45605274/128910772-4497158a-5ad3-4267-969d-874225bb03a7.png">

referencia: ([link](https://frescolib.org/docs/rounded-corners-and-circles.html))


### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
