### PR TITLE
Fix CoverCarousel Row view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## SIN PUBLICAR
+- Se fixea el solapamiento de vistas en la row del CoverCarousel.
 
 ## 2.1.0
  - Se customiza el font size e image size de MainDescriptionLabelText y MainDescriptionLabelImage.

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/row/TouchpointRowView.java
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.mlbusinesscomponents.components.row;
 
 import android.content.Context;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Rect;
 import androidx.annotation.Nullable;
@@ -93,7 +94,6 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
         rippleView = findViewById(R.id.discounts_payers_list_row_click);
         rightBottomInfoContainer.bindViews();
         presenter = new TouchpointRowPresenter();
-        post(this::analyzeComponentsPositions);
     }
 
     /**
@@ -447,6 +447,12 @@ public class TouchpointRowView extends ViewSwitcher implements OnClickCallback {
         final Rect intersectedView) {
         return firstViewRect.intersect(intersectedView) || secondViewRect.intersect(intersectedView) ||
             thirdViewRect.intersect(intersectedView);
+    }
+
+    @Override
+    protected void onDraw(final Canvas canvas) {
+        super.onDraw(canvas);
+        analyzeComponentsPositions();
     }
 
     private void analyzeComponentsPositions() {


### PR DESCRIPTION
## Descripción
- Se corrige el solapamiento de vistas en la Row del CoverCarousel

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

BUG | FIX
------ | ------
<img width="600" alt="Screen Shot 2021-11-30 at 15 26 47" src="https://user-images.githubusercontent.com/51420540/144106163-ab13d28e-951a-43f0-9689-908a95b05607.png"> | <img width="644" alt="Screen Shot 2021-11-30 at 15 26 55" src="https://user-images.githubusercontent.com/51420540/144106201-0c7dab96-74d7-4d21-b303-fc06295c501c.png">

### Checklist
- [x] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [x] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [x] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
