### PR TITLE
Fix/button progress colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## SIN PUBLICAR
+- Se arregla un bug en el componente ButtonProgress.
 
 ## 2.2.1
 - Revert bump Kotlin 1.5.

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
@@ -129,10 +129,10 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
         paintText(R.color.ui_meli_white);
     }
 
-    public ButtonProgress setColorButton(int backgroundColor, int progressColor) {
-        this.backgroundColor = backgroundColor;
-        this.progressColor = progressColor;
-        paintButton(backgroundColor, progressColor);
+    public ButtonProgress setColorButton(@ColorRes int backgroundColor, @ColorRes int progressColor) {
+        this.backgroundColor = ContextCompat.getColor(getContext(), backgroundColor);
+        this.progressColor = ContextCompat.getColor(getContext(), progressColor);
+        paintButton(this.backgroundColor, this.progressColor);
         return this;
     }
 
@@ -232,7 +232,6 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
         animator = ObjectAnimator.ofInt(progressBar, "progress", 0, durationTimeout);
         adjustHeight(circle);
         adjustHeight(icon);
-
 
         backgroundColor = ContextCompat.getColor(context, R.color.components_primary_color);
         progressColor = ContextCompat.getColor(context, R.color.components_secondary_color);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
@@ -109,7 +109,10 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
     public void setState(ButtonProgressState state) {
         if (state == DISABLED) {
             this.setClickable(false);
-            paintButton(R.color.mlbusiness_color_disable_button, R.color.mlbusiness_color_disable_button);
+            paintButton(
+                ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button),
+                ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button)
+            );
             paintText(R.color.ui_meli_white);
         } else {
             this.setClickable(true);

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
@@ -52,10 +52,10 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
     private int rippleColor;
     @ColorRes
     private int colorText;
-    @ColorRes
-    private int backgroundColor = R.color.components_primary_color;
-    @ColorRes
-    private int progressColor = R.color.components_secondary_color;
+    @ColorInt
+    private int backgroundColor;
+    @ColorInt
+    private int progressColor;
     private String titleProgress;
     private int durationRipple = 500;
     private int durationTimeout = 7000;
@@ -133,7 +133,7 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
         LayerDrawable dr = (LayerDrawable) getResources().getDrawable(R.drawable.button_background);
         GradientDrawable background = (GradientDrawable) dr.findDrawableByLayerId(R.id.background);
         ClipDrawable progress = (ClipDrawable) dr.findDrawableByLayerId(R.id.progress);
-        background.setColor(ContextCompat.getColor(getContext(), backgroundColor));
+        background.setColor(backgroundColor);
         DrawableCompat.setTint(progress, progressColor);
         progressBar.setProgressDrawable(dr);
     }
@@ -221,6 +221,10 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
         animator = ObjectAnimator.ofInt(progressBar, "progress", 0, durationTimeout);
         adjustHeight(circle);
         adjustHeight(icon);
+
+
+        backgroundColor = ContextCompat.getColor(context, R.color.components_primary_color);
+        progressColor = ContextCompat.getColor(context, R.color.components_secondary_color);
     }
 
     @Override

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/explodingbutton/ButtonProgress.java
@@ -108,17 +108,25 @@ public class ButtonProgress extends LinearLayout implements View.OnClickListener
 
     public void setState(ButtonProgressState state) {
         if (state == DISABLED) {
-            this.setClickable(false);
-            paintButton(
-                ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button),
-                ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button)
-            );
-            paintText(R.color.ui_meli_white);
+            setDisabledState();
         } else {
-            this.setClickable(true);
-            paintButton(backgroundColor, progressColor);
-            paintText(colorText);
+            setEnabledState();
         }
+    }
+
+    private void setEnabledState() {
+        this.setClickable(true);
+        paintButton(backgroundColor, progressColor);
+        paintText(colorText);
+    }
+
+    private void setDisabledState() {
+        this.setClickable(false);
+        paintButton(
+            ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button),
+            ContextCompat.getColor(getContext(), R.color.mlbusiness_color_disable_button)
+        );
+        paintText(R.color.ui_meli_white);
     }
 
     public ButtonProgress setColorButton(int backgroundColor, int progressColor) {


### PR DESCRIPTION
## Descripción

Se arregla un bug en el componente ButtonProgress. El color progress no se estaba tomando correctamente al setear un estado.


## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

Bug | Fix
---------|---------
![bugButtonProgress](https://user-images.githubusercontent.com/11901964/152859933-1dcb6add-45e2-4f4e-915d-3b3913269134.gif) | ![fixButtonProgress](https://user-images.githubusercontent.com/11901964/152860116-f2113db3-4a3f-46c1-af9d-322ea6619cfe.gif)









### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
