### PR TITLE
Removed app name content description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## SIN PUBLICAR
+- Se borra el content description con el app name por accesibilidad
 
 ## 2.2.1
 - Revert bump Kotlin 1.5.

--- a/mlbusinesscomponents/src/main/res/layout/ml_view_business_discount_box_item.xml
+++ b/mlbusinesscomponents/src/main/res/layout/ml_view_business_discount_box_item.xml
@@ -31,8 +31,7 @@
                     android:layout_width="@dimen/ui_7m"
                     android:layout_height="@dimen/ui_7m"
                     android:scaleType="centerInside"
-                    tools:src="@drawable/mercado_pago"
-                    android:contentDescription="@string/app_name" />
+                    tools:src="@drawable/mercado_pago" />
 
                 <View
                     android:id="@+id/discount_item_overlay"

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_carousel_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_carousel_card_view.xml
@@ -34,8 +34,7 @@
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
                 app:actualImageScaleType="centerCrop"
-                app:roundAsCircle="true"
-                android:contentDescription="@string/app_name" />
+                app:roundAsCircle="true"/>
 
             <View
                 android:id="@+id/touchpoint_carousel_card_logo_overlay"

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_default_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_default_card_view.xml
@@ -32,8 +32,7 @@
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
                 app:roundAsCircle="true"
-                app:actualImageScaleType="centerCrop"
-                android:contentDescription="@string/app_name" />
+                app:actualImageScaleType="centerCrop" />
 
             <View
                 android:id="@+id/touchpoint_hybrid_carousel_default_card_top_image_overlay"
@@ -47,8 +46,7 @@
                 android:layout_height="@dimen/image_accessory_height"
                 android:scaleType="fitCenter"
                 android:layout_gravity="bottom|end"
-                android:src="@drawable/skeleton"
-                android:contentDescription="@string/app_name" />
+                android:src="@drawable/skeleton" />
 
         </FrameLayout>
 

--- a/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_view_more_card_view.xml
+++ b/mlbusinesscomponents/src/main/res/layout/touchpoint_hybrid_carousel_view_more_card_view.xml
@@ -36,8 +36,7 @@
                 tools:src="@drawable/mercado_pago"
                 android:src="@drawable/skeleton"
                 app:roundAsCircle="true"
-                app:actualImageScaleType="centerCrop"
-                android:contentDescription="@string/app_name" />
+                app:actualImageScaleType="centerCrop" />
 
             <View
                 android:id="@+id/touchpoint_hybrid_carousel_view_more_card_top_image_overlay"


### PR DESCRIPTION
## Descripción

Se borra el atributo contentDescription con el nombre de la app para que cuando se utilizan los carouseles con la herramienta de Accesibilidad, la misma no lea el nombre de la app si no que lea el texto que se encuentra en el Carousel. 

## Tipo:

- [x] Bugfix
- [ ] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

[Si aplica, adjuntar screenshots en un solo idioma donde se vea el flujo completo]

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
