### PR TITLE
Remove margins start & end

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Compress Images
-        uses: calibreapp/image-actions@master
+        uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           jpegQuality: "80"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Sin publicar
+- Se borra el margin start y end en los carouseles.
+
+## 2.6.0
 - Se actualiza container Card Full View.
 
 ## 2.5.0

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/CarouselAdapter.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/CarouselAdapter.java
@@ -62,6 +62,12 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.Carous
         holder.setExtraData(extraData);
         holder.setCanOpenMercadoPago(isMPInstalled);
         holder.setImageLoader(imageLoader);
+        if (index == 0) {
+            holder.removeMarginStartFirstItem();
+        }
+        if (getItemCount() - 1 == index) {
+            holder.removeMarginEndLastItem();
+        }
     }
 
     @Override
@@ -158,6 +164,14 @@ public class CarouselAdapter extends RecyclerView.Adapter<CarouselAdapter.Carous
         /* default */ void setImageLoader(final TouchpointImageLoader touchpointImageLoader) {
             if (touchpointImageLoader == null) return;
             currentView.setImageLoader(touchpointImageLoader);
+        }
+
+        /* default */ void removeMarginStartFirstItem() {
+            currentView.removeMarginStart();
+        }
+
+        /* default */ void removeMarginEndLastItem() {
+            currentView.removeMarginEnd();
         }
     }
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/CarouselCardInterface.kt
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/CarouselCardInterface.kt
@@ -49,4 +49,14 @@ interface CarouselCardInterface {
      * @param imageLoader The image loader.
      */
     fun setImageLoader(imageLoader: TouchpointImageLoader)
+
+    /**
+     * Remove margins start of first item.
+     */
+    fun removeMarginStart()
+
+    /**
+     * Remove margins end of last item.
+     */
+    fun removeMarginEnd()
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card/CarouselCardView.java
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card/CarouselCardView.java
@@ -517,4 +517,16 @@ public class CarouselCardView extends CardView implements TouchpointTrackeable, 
     public void setImageLoader(final TouchpointImageLoader imageLoader) {
         AssetLoader.setStrategy(imageLoader);
     }
+
+    @Override
+    public void removeMarginStart() {
+        MarginLayoutParams params = (MarginLayoutParams) getLayoutParams();
+        params.setMargins(0, params.topMargin, params.rightMargin, params.bottomMargin);
+    }
+
+    @Override
+    public void removeMarginEnd() {
+        MarginLayoutParams params = (MarginLayoutParams) getLayoutParams();
+        params.setMargins(params.leftMargin, params.topMargin, 0, params.bottomMargin);
+    }
 }

--- a/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card_full/CarouselCardFullView.kt
+++ b/mlbusinesscomponents/src/main/java/com/mercadolibre/android/mlbusinesscomponents/components/touchpoint/view/carousel/card_full/CarouselCardFullView.kt
@@ -152,6 +152,16 @@ class CarouselCardFullView @JvmOverloads constructor(
         AssetLoader.setStrategy(imageLoader)
     }
 
+    override fun removeMarginStart() {
+        val params = (layoutParams as MarginLayoutParams)
+        params.setMargins(0, params.topMargin, params.rightMargin, params.bottomMargin)
+    }
+
+    override fun removeMarginEnd() {
+        val params = (layoutParams as MarginLayoutParams)
+        params.setMargins(params.leftMargin, params.topMargin, 0, params.bottomMargin)
+    }
+
     /**
      * Returns the title font style to a default value
      */


### PR DESCRIPTION
## Descripción

Se ajustan los margenes del primer elemento de carousel eliminando su margin start y para el elemento final de carousel el margin end.

## Tipo:

- [ ] Bugfix
- [x] Feature or Improvement

## Issues.

- Fixes #issue1

## Screenshots - Gifs

<p align="center">
  <img src="https://user-images.githubusercontent.com/63241844/163047308-561bf16b-1e50-4032-8283-c8da3f2ecbbf.jpg" alt="" width="300"/>
</p>

### Checklist
- [ ] Chequeado con el equipo de central de descuentos (Obligatorio)
- [ ] Probé la biblioteca en PX (Obligatorio)
- [ ] Probé la biblioteca en Mercado Pago (Obligatorio)
- [ ] Probé la biblioteca en Mercado Libre (Obligatorio)
- [ ] Modifiqué el [changelog](https://github.com/mercadolibre/mlbusiness-components-android/blob/master/CHANGELOG.md)

## Aclaraciones importantes
**Quien crea el PR, es el responsable de regresionar los modulos afectados**
